### PR TITLE
:bug: Update example to support 100+ longitudes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class MyDataObject extends DataObject
 {
     private static $db = [
         'Latitude' => 'Decimal(10, 8)',
-        'Longitude' => 'Decimal(10, 8)'
+        'Longitude' => 'Decimal(11, 8)'
     ];
 
     public function getCMSFields()


### PR DESCRIPTION
Thanks for this great module!

I found an issue with the example code. In New Zealand, our longitudes are over 100 and your example only allowed for longitudes under 100.

If you look up **4 Dowling Street, Dunedin, New Zealand** `(-45.866500,170.484440)`, the mapfield will work initially, but once you save or reload the page, the map goes blank. This is because in the database it saved with latitude `-45.866500` and longitude `99.9999999` due to the decimal db field constraints.

I've increased the decimal up one so others don't run into this, it took a while to track it down :)
